### PR TITLE
連続値パラメータのバッチ評価によるGPSamplerの高速化

### DIFF
--- a/optuna/_gp/batched_lbfgsb.py
+++ b/optuna/_gp/batched_lbfgsb.py
@@ -1,0 +1,330 @@
+"""
+Please note that this is a port of the L-BFGS-B iplementation from SciPy and this implementation
+may not work in future due to the dependency on the SciPy's internal API.
+
+Heavily modified to adapt to Optuna by Shuhei Watanabe (2025) <shuhei.watanabe.utokyo@gmail.com>
+
+License for the Python wrapper
+==============================
+
+Copyright (c) 2004 David M. Cooke <cookedm@physics.mcmaster.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Modifications by Travis Oliphant and Enthought, Inc. for inclusion in SciPy
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from packaging.version import Version
+from scipy import __version__ as scipy_version
+from scipy.optimize import _lbfgsb as scipy_lbfgsb
+
+if TYPE_CHECKING:
+    from typing import Any, Protocol
+
+    class FuncAndGrad(Protocol):
+        def __call__(
+            self, x: np.ndarray, unconverged_batch_indices: np.ndarray
+        ) -> tuple[np.ndarray, np.ndarray]:
+            raise NotImplementedError
+
+
+status_messages = {
+    0: "START",
+    1: "NEW_X",
+    2: "RESTART",
+    3: "FG",
+    4: "CONVERGENCE",
+    5: "STOP",
+    6: "WARNING",
+    7: "ERROR",
+    8: "ABNORMAL",
+}
+task_messages = {
+    0: "",
+    301: "",
+    302: "",
+    401: "NORM OF PROJECTED GRADIENT <= PGTOL",
+    402: "RELATIVE REDUCTION OF F <= FACTR*EPSMCH",
+    501: "CPU EXCEEDING THE TIME LIMIT",
+    502: "TOTAL NO. OF F,G EVALUATIONS EXCEEDS LIMIT",
+    503: "PROJECTED GRADIENT IS SUFFICIENTLY SMALL",
+    504: "TOTAL NO. OF ITERATIONS REACHED LIMIT",
+    505: "CALLBACK REQUESTED HALT",
+    601: "ROUNDING ERRORS PREVENT PROGRESS",
+    602: "STP = STPMAX",
+    603: "STP = STPMIN",
+    604: "XTOL TEST SATISFIED",
+    701: "NO FEASIBLE SOLUTION",
+    702: "FACTR < 0",
+    703: "FTOL < 0",
+    704: "GTOL < 0",
+    705: "XTOL < 0",
+    706: "STP < STPMIN",
+    707: "STP > STPMAX",
+    708: "STPMIN < 0",
+    709: "STPMAX < STPMIN",
+    710: "INITIAL G >= 0",
+    711: "M <= 0",
+    712: "N <= 0",
+    713: "INVALID NBD",
+}
+_is_lbfgsb_fortran = Version(scipy_version) < Version("1.15.0")
+
+
+class _DataConstantInPython:
+    def __init__(
+        self,
+        batch_size: int,
+        bounds: np.ndarray,
+        m: int,
+        factr: float,
+        pgtol: float,
+        maxls: int,
+    ) -> None:
+        # See https://github.com/scipy/scipy/blob/v1.15.0/scipy/optimize/__lbfgsb.c
+        self._csave: np.ndarray | None
+        self._ln_task: np.ndarray | None
+        int_type = scipy_lbfgsb.types.intvar.dtype if _is_lbfgsb_fortran else np.int32
+        if _is_lbfgsb_fortran:
+            self._ln_task = None
+            self._csave = np.zeros((batch_size, 1), dtype="S60")
+        else:
+            self._ln_task = np.zeros((batch_size, 2), dtype=int_type)
+            self._csave = None
+
+        self._m = m
+        self._factr = factr
+        self._pgtol = pgtol
+        self._maxls = maxls
+        dim = len(bounds[0])
+        self._l = np.where(np.isinf(bounds[0]), 0.0, bounds[0])  # Lower bounds
+        self._u = np.where(np.isinf(bounds[1]), 0.0, bounds[1])  # Upper bounds
+        bounds_map = {
+            (False, False): 0,
+            (True, False): 1,
+            (True, True): 2,
+            (False, True): 3,
+        }
+        self._nbd = np.array(
+            [bounds_map[if1, if2] for if1, if2 in zip(*np.isfinite(bounds).tolist())],
+            dtype=int_type,
+        )
+        self._wa = np.zeros(
+            (batch_size, 2 * m * dim + 5 * dim + 11 * m**2 + 8 * m), dtype=np.float64
+        )
+        self._iwa = np.zeros((batch_size, 3 * dim), dtype=int_type)
+        self._lsave = np.zeros((batch_size, 4), dtype=int_type)
+        self._isave = np.zeros((batch_size, 44), dtype=int_type)
+        self._dsave = np.zeros((batch_size, 29), dtype=np.float64)
+
+    def lbfgsb_args(
+        self,
+        batch_id: int,
+        task_status: np.ndarray,
+        x: np.ndarray,
+        f: np.ndarray,
+        g: np.ndarray,
+    ) -> Any:
+        return (
+            self._m,
+            x,
+            self._l,
+            self._u,
+            self._nbd,
+            f,
+            g,
+            self._factr,
+            self._pgtol,
+            self._wa[batch_id],
+            self._iwa[batch_id],
+            task_status,
+            *((-1,) if _is_lbfgsb_fortran else ()),
+            *((self._csave[batch_id],) if self._csave is not None else ()),
+            self._lsave[batch_id],
+            self._isave[batch_id],
+            self._dsave[batch_id],
+            self._maxls,
+            *((self._ln_task[batch_id],) if self._ln_task is not None else ()),
+        )
+
+
+class _TaskStatusManager:
+    def __init__(self, batch_size: int, max_iters: int, max_evals: int) -> None:
+        if _is_lbfgsb_fortran:
+            self.task_status = np.full((batch_size, 1), status_messages[0], dtype="S60")
+        else:
+            self.task_status = np.zeros((batch_size, 2), dtype=np.int32)
+
+        self.is_batch_terminated = np.zeros(batch_size, dtype=bool)
+        self._max_iters = max_iters
+        self._max_evals = max_evals
+        self._batch_size = batch_size
+        self._n_iterations = np.zeros(batch_size, dtype=int)
+        self._n_evals = np.zeros(batch_size, dtype=int)
+
+    def _update_task_status(self, batch_id: int, status_id: int, task_id: int) -> None:
+        if _is_lbfgsb_fortran:
+            self.task_status[batch_id] = f"{status_messages[status_id]}: {task_messages[task_id]}"
+        else:
+            self.task_status[batch_id] = [status_id, task_id]
+
+    def _judge_status(self, batch_id: int, status_id: int) -> bool:
+        if _is_lbfgsb_fortran:
+            expected_msg = status_messages[status_id].encode()
+            return self.task_status[batch_id].tobytes().startswith(expected_msg)
+        else:
+            return bool(self.task_status[batch_id, 0] == status_id)
+
+    def reach_iter_limit(self, batch_id: int) -> bool:
+        if reach_limit := self._n_iterations[batch_id] >= self._max_iters:
+            self.is_batch_terminated[batch_id] = True
+            self._update_task_status(batch_id, 5, 504)
+        return reach_limit
+
+    def reach_eval_limit(self, batch_id: int) -> bool:
+        if reach_limit := self._n_evals[batch_id] > self._max_evals:
+            self.is_batch_terminated[batch_id] = True
+            self._update_task_status(batch_id, 5, 502)
+        return reach_limit
+
+    def should_evaluate(self, batch_id: int) -> bool:
+        if should_evaluate := self._judge_status(batch_id, status_id=3):
+            self._n_evals[batch_id] += 1
+        return should_evaluate
+
+    def should_terminate_batch(self, batch_id: int) -> bool:
+        b = batch_id
+        if self.is_batch_terminated[b]:
+            return True
+        elif self._judge_status(b, status_id=1):  # New parameter suggested.
+            self._n_iterations[b] += 1  # This timing follows SciPy.
+            self.is_batch_terminated[b] = self.reach_iter_limit(b) or self.reach_eval_limit(b)
+        elif not self._judge_status(b, status_id=0) and not self._judge_status(b, status_id=3):
+            # 0: Start, 3: Next function evaluation.
+            self.is_batch_terminated[b] = True
+        return self.is_batch_terminated[b]
+
+    @property
+    def info(self) -> dict[str, list[bool] | list[int] | list[str]]:
+        messages = [
+            (
+                ts.tobytes().decode().rstrip("\x00")
+                if _is_lbfgsb_fortran
+                else f"{status_messages[ts[0]]}: {task_messages[ts[1]]}"
+            )
+            for ts in self.task_status
+        ]
+        return {
+            "is_converged": [self._judge_status(b, status_id=4) for b in range(self._batch_size)],
+            "n_iterations": self._n_iterations.tolist(),
+            "n_evals": self._n_evals.tolist(),
+            "messages": messages,
+        }
+
+
+def batched_lbfgsb(
+    func_and_grad: FuncAndGrad,
+    x0: np.ndarray,
+    bounds: np.ndarray | None = None,
+    m: int = 10,
+    factr: float = 1e7,
+    pgtol: float = 1e-5,
+    max_evals: int = 15000,
+    max_iters: int = 15000,
+    max_line_search: int = 20,
+) -> tuple[np.ndarray, np.ndarray, dict[str, list[bool] | list[int] | list[str]]]:
+    """
+    Minimize a batched function of one or more variables using the L-BFGS-B algorithm.
+
+    Args:
+        x0:
+            Initial guess with the shape of (batch_size, dimension).
+        bounds:
+            The lower and upper bounds of each parameter with the shape of (dimension, 2).
+            ``(min, max)`` pairs for each element in ``x``, defining the bounds on that parameter.
+            Use None or +-inf when there is no bound in that direction.
+        m:
+            The maximum number of variable metric corrections used to define the limited memory
+            matrix. (The limited memory BFGS method does not store the full Hessian but uses this
+            many terms in an approximation to it.)
+        factr:
+            The iteration stops when ``(f^k - f^{k+1})/max{|f^k|,|f^{k+1}|,1} <= factr * eps``,
+            where ``eps`` is the machine precision, which is automatically generated by the code.
+            Typical values for `factr` are: 1e12 for low accuracy; 1e7 for moderate accuracy; 10.0
+            for extremely high accuracy.
+        pgtol:
+            The iteration will stop when ``max{|proj g_i | i = 1, ..., n} <= pgtol`` where
+            ``proj g_i`` is the i-th component of the projected gradient.
+        max_evals:
+            Maximum number of function evaluations before minimization terminates.
+        max_iters:
+            Maximum number of algorithm iterations.
+        max_line_search:
+            Maximum number of line search steps (per iteration). Default is 20.
+
+    Returns:
+        A tuple containing:
+        - The optimized parameters with the shape of (batch_size, dimension).
+        - The function values at the optimized parameters with the shape of (batch_size,).
+        - A dictionary containing convergence information, including:
+            - `is_converged`: A list of booleans indicating whether each batch converged.
+            - `n_iterations`: A list of the number of iterations for each batch.
+            - `n_evals`: A list of the number of function evaluations for each batch.
+            - `messages`: A list of messages indicating the status of each batch.
+
+    Notes:
+        SciPy uses a C-translated and modified version of the Fortran code, L-BFGS-B v3.0
+        (released April 25, 2011, BSD-3 licensed). Original Fortran version was written by
+        Ciyou Zhu, Richard Byrd, Jorge Nocedal and, Jose Luis Morales.
+
+    References:
+        * R. H. Byrd, P. Lu and J. Nocedal. A Limited Memory Algorithm for Bound Constrained
+        Optimization, (1995), SIAM Journal on Scientific and Statistical Computing, 16, 5,
+        pp. 1190-1208.
+        * C. Zhu, R. H. Byrd and J. Nocedal. L-BFGS-B: Algorithm 778: L-BFGS-B, FORTRAN routines
+        for large scale bound constrained optimization (1997), ACM Transactions on
+        Mathematical Software, 23, 4, pp. 550 - 560.
+        * J.L. Morales and J. Nocedal. L-BFGS-B: Remark on Algorithm 778: L-BFGS-B, FORTRAN
+        routines for large scale bound constrained optimization (2011), ACM Transactions on
+        Mathematical Software, 38, 1.
+    """
+    batched_x = x0.reshape(-1, (original_x_shape := x0.shape)[-1]).copy()
+    b_indices = np.arange((batch_size := len(batched_x)), dtype=int)
+    bounds = np.array([[-np.inf, np.inf]] * x0.shape[-1]).T if bounds is None else bounds.T
+    data = _DataConstantInPython(batch_size, bounds, m, factr, pgtol, max_line_search)
+    f_vals = np.zeros(batch_size, dtype=np.float64)
+    grads = np.zeros_like(batched_x, dtype=np.float64)
+    tm = _TaskStatusManager(batch_size, max_iters=max_iters, max_evals=max_evals)
+    while (unconverged_batch_indices := b_indices[~tm.is_batch_terminated]).size:
+        f_vals[unconverged_batch_indices], grads[unconverged_batch_indices] = func_and_grad(
+            batched_x[unconverged_batch_indices], unconverged_batch_indices
+        )
+        for b in unconverged_batch_indices:
+            lbfgsb_args = data.lbfgsb_args(b, tm.task_status[b], batched_x[b], f_vals[b], grads[b])
+            while not tm.should_terminate_batch(b):
+                scipy_lbfgsb.setulb(*lbfgsb_args)  # x,f,g,task_status will be updated inplace.
+                if tm.should_evaluate(b):
+                    break
+    return (
+        batched_x.reshape(original_x_shape),
+        f_vals.reshape(original_x_shape[:-1]),
+        tm.info,
+    )

--- a/optuna/_gp/batched_lbfgsb.py
+++ b/optuna/_gp/batched_lbfgsb.py
@@ -234,7 +234,7 @@ class _TaskStatusManager:
         ]
         return {
             "is_converged": [self._judge_status(b, status_id=4) for b in range(self._batch_size)],
-            "n_iterations": self._n_iterations.tolist(),
+            "nit": self._n_iterations.tolist(),
             "n_evals": self._n_evals.tolist(),
             "messages": messages,
         }

--- a/optuna/_gp/optim_mixed.py
+++ b/optuna/_gp/optim_mixed.py
@@ -8,7 +8,6 @@ import numpy as np
 from optuna._gp.scipy_blas_thread_patch import single_blas_thread_if_scipy_v1_15_or_newer
 from optuna.logging import get_logger
 
-
 if TYPE_CHECKING:
     import scipy.optimize as so
 
@@ -133,8 +132,9 @@ def _discrete_line_search(
             return np.inf
         right = int(np.clip(np.searchsorted(grids, x), 1, len(grids) - 1))
         left = right - 1
-        neg_acqf_left, neg_acqf_right = negative_acqf_with_cache(left), negative_acqf_with_cache(
-            right
+        neg_acqf_left, neg_acqf_right = (
+            negative_acqf_with_cache(left),
+            negative_acqf_with_cache(right),
         )
         w_left = (grids[right] - x) / (grids[right] - grids[left])
         w_right = 1.0 - w_left
@@ -168,7 +168,6 @@ def _local_search_discrete(
     choices: np.ndarray,
     xtol: float,
 ) -> tuple[np.ndarray, float, bool]:
-
     # If the number of possible parameter values is small, we just perform an exhaustive search.
     # This is faster and better than the line search.
     MAX_INT_EXHAUSTIVE_SEARCH_PARAMS = 16
@@ -256,15 +255,14 @@ def optimize_acqf_mixed(
     tol: float = 1e-4,
     rng: np.random.RandomState | None = None,
 ) -> tuple[np.ndarray, float]:
-
     rng = rng or np.random.RandomState()
 
     if warmstart_normalized_params_array is None:
         warmstart_normalized_params_array = np.empty((0, acqf.search_space.dim))
 
-    assert (
-        len(warmstart_normalized_params_array) <= n_local_search - 1
-    ), "We must choose at least 1 best sampled point + given_initial_xs as start points."
+    assert len(warmstart_normalized_params_array) <= n_local_search - 1, (
+        "We must choose at least 1 best sampled point + given_initial_xs as start points."
+    )
 
     sampled_xs = acqf.search_space.sample_normalized_params(n_preliminary_samples, rng=rng)
 

--- a/optuna/_gp/optim_mixed.py
+++ b/optuna/_gp/optim_mixed.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import scipy
 import torch
-import scipy
-import torch
 
-from optuna._gp.batched_lbfgsb import batched_lbfgsb
 from optuna._gp.batched_lbfgsb import batched_lbfgsb
 from optuna._gp.scipy_blas_thread_patch import single_blas_thread_if_scipy_v1_15_or_newer
 from optuna.logging import get_logger
@@ -31,14 +28,7 @@ def is_scipy_version_supported() -> bool:
 
 
 def _gradient_ascent_batched(
-def is_scipy_version_supported() -> bool:
-    return scipy.__version__ <= "1.15.0"
-
-
-def _gradient_ascent_batched(
     acqf: BaseAcquisitionFunc,
-    initial_params_batched: np.ndarray,
-    initial_fvals: np.ndarray,
     initial_params_batched: np.ndarray,
     initial_fvals: np.ndarray,
     continuous_indices: np.ndarray,
@@ -68,17 +58,6 @@ def _gradient_ascent_batched(
         scaled_x: np.ndarray, unconverged_batch_indices: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:
         # Scale back to the original domain, i.e. [0, 1], from [0, 1/s].
-        assert scaled_x.ndim == 2
-        normalized_params[np.ix_(unconverged_batch_indices, continuous_indices)] = (
-            scaled_x * lengthscales
-        )
-        x_tensor = torch.from_numpy(
-            normalized_params[unconverged_batch_indices, :]
-        ).requires_grad_(True)
-        neg_fvals = -acqf.eval_acqf(x_tensor)
-        neg_fvals.sum().backward()
-        grads = x_tensor.grad.detach().numpy()  # type: ignore
-        neg_fvals = neg_fvals.detach().numpy()
         assert scaled_x.ndim == 2
         normalized_params[np.ix_(unconverged_batch_indices, continuous_indices)] = (
             scaled_x * lengthscales
@@ -284,7 +263,6 @@ def _local_search_discrete_batched(
 def local_search_mixed_batched(
     acqf: BaseAcquisitionFunc,
     initial_normalized_params_batched: np.ndarray,
-    initial_normalized_params_batched: np.ndarray,
     *,
     tol: float = 1e-4,
     max_iter: int = 100,
@@ -418,9 +396,6 @@ def optimize_acqf_mixed(
     best_x = sampled_xs[max_i, :]
     best_f = float(f_vals[max_i])
 
-    x_warmstarts = np.vstack([sampled_xs[chosen_idxs, :], warmstart_normalized_params_array])
-    xs, fs = local_search_mixed_batched(acqf, x_warmstarts, tol=tol)
-    for x, f in zip(xs, fs):
     x_warmstarts = np.vstack([sampled_xs[chosen_idxs, :], warmstart_normalized_params_array])
     xs, fs = local_search_mixed_batched(acqf, x_warmstarts, tol=tol)
     for x, f in zip(xs, fs):


### PR DESCRIPTION
## 概要 (Summary)

本PRは、GPSampler における連続パラメータの獲得関数の最適化処理を高速化するため、バッチ評価を導入します。これにより、特に連続値パラメータを多く含む目的関数において、最適化の実行時間を大幅に短縮することを目指します。

## 提案手法 (Solution)

連続値パラメータの最適化処理を複数同時に実行する「バッチ評価」機能を実装しました。

- **バッチ評価 (Batched Evaluation)**: 複数のTrialにまたがる連続値パラメータの最適化計算をまとめて実行します。これにより、計算リソースを効率的に利用し、処理時間を短縮します。ただし、SciPyの内部モジュールに依存しているため、問題があれば従来の逐次実行にもすぐに切り替えできるようにします。（フォールバック）
- **フォールバック (Fallback)**: SciPyの内部モジュールのAPIが変更した場合など、バッチ評価の前提条件が満たされない場合は、安全に従来の逐次評価処理へ切り替わります。

これらの切り替えは、`optim_mixed.py`の`_gradient_ascent_batched`関数の内部の条件分岐で切り替わります。こちらの条件分岐を適宜変える（`if False: ...`にするなど）ことで、簡単にバッチ評価から逐次評価に切り替えることができます。

```python

def _gradient_ascent_batched(...):
	...
	# SciPyの内部モジュールが利用可能な場合、バッチ評価を行う
	if is_scipy_version_supported():
		scaled_cont_x_opts, neg_fval_opts, info = batched_lbfgsb(...)
		...


	else: # Fallback
		...
		for batch, x0 in enumerate(x0_batched):
			...
			scaled_cont_x_opt, neg_fval_opt, info = so.fmin_l_bfgs_b(...)
			...
```

現状の切り替えは、`is_scipy_version_supported`関数にて切り替えの判定を行なっており、これは次のように定義されています。

```python
def is_scipy_version_supported() -> bool:
    return scipy.__version__ <= "1.15.0"
```

つまりSciPyのバージョンが`1.15.0`以下ならバッチ評価を、そうでなければ逐次評価を行うということです。

## 実験結果 (Experimental Results)

提案手法の有効性を確認するため、以下の2つの実験を行いました。
- `Original`: masterブランチの挙動
- `This PR (Batched)`: 提案手法のバッチ評価が機能した場合
- `This PR (Fallback)`: 提案手法がフォールバックした場合

**実験設定**
- `n_trials`: 100
- `seed`: 42
- `CPU`: M4 Mac

---

### 実験1: Rotated Ellipsoid + 離散変数

連続変数と離散変数が混在する問題設定です。

**目的関数**
```python
import numpy as np

NUM_CONTINUOUS_PARAMS = 3
# rotation matrix
ROTATION_MATRIX, _ = np.linalg.qr(np.random.rand(NUM_CONTINUOUS_PARAMS, NUM_CONTINUOUS_PARAMS))

def objective(trial):
    xs = np.array([trial.suggest_float(f"x_{i}", -1, 1) for i in range(NUM_CONTINUOUS_PARAMS)])
    xs = ROTATION_MATRIX @ xs
    z = trial.suggest_int("z", 0, 5)
    w = trial.suggest_int("w", 0, 2)
    return np.sum(xs**2) + (z - 2) ** 2 + (w - 1) ** 2
```

#### 結果1. 実行時間と目的関数の最適値

| stats\mode   | This PR (Batched) | This PR (Fallback) | Original    |
| ------------ | ----------------- | ------------------ | ----------- |
| Runtime      | 4.24 sec          | 5.47 sec           | 5.46 sec    |
| `best_value` | `8.491e-06`       | `5.264e-06`        | `1.173e-05` |

#### 結果2. Trialの初期では、どの手法も最適解がほとんど一致する

| Trial | Mode               | x0                   | x1                  | x2                   | z   | w   |
| ----- | ------------------ | -------------------- | ------------------- | -------------------- | --- | --- |
| 9     | Original           | 0.32504456870796394  | -0.3765778478211781 | 0.040136042355621626 | 3   | 0   |
| 9     | This PR (Batched)  | 0.32504456870796394  | -0.3765778478211781 | 0.040136042355621626 | 3   | 0   |
| 9     | This PR (Fallback) | 0.32504456870796394  | -0.3765778478211781 | 0.040136042355621626 | 3   | 0   |
| 10    | Original           | 0.04939102872817558  | 0.5183390069820595  | -1.0                 | 2   | 2   |
| 10    | This PR (Batched)  | 0.04939102872819379  | 0.5183390069820168  | -1.0                 | 2   | 2   |
| 10    | This PR (Fallback) | 0.049391028728263064 | 0.5183390069820635  | -1.0                 | 2   | 2   |
| 11    | Original           | 1.0                  | -1.0                | -1.0                 | 2   | 0   |
| 11    | This PR (Batched)  | 0.9999999999999998   | -1.0                | -1.0                 | 2   | 0   |
| 11    | This PR (Fallback) | 1.0                  | -1.0                | -1.0                 | 2   | 0   |
| 12    | Original           | 0.01292647202538677  | -1.0                | 0.683606077907549    | 2   | 1   |
| 12    | This PR (Batched)  | 0.012926472025411861 | -1.0                | 0.68360607790766     | 2   | 1   |
| 12    | This PR (Fallback) | 0.012926472025397429 | -1.0                | 0.6836060779076483   | 2   | 1   |
| 13    | Original           | -0.20230895590596554 | -1.0                | -0.6996612111149964  | 2   | 1   |
| 13    | This PR (Batched)  | -0.20230895590596643 | -1.0                | -0.6996612111149789  | 2   | 1   |
| 13    | This PR (Fallback) | -0.2023089559059673  | -1.0                | -0.6996612111149729  | 2   | 1   |

---

### 実験2: BBOB F6 (次元d=10)

連続変数のみを含むベンチマーク問題です。ベンチマークは[The blackbox optimization benchmarking (bbob) test suite \| OptunaHub](https://hub.optuna.org/benchmarks/bbob/)のものを利用しています。

**目的関数**
```python
import optunahub

bbob = optunahub.load_module("benchmarks/bbob")
f6 = bbob.Problem(function_id=6, dimension=10, instance_id=1)
```

#### 結果1. 実行時間と目的関数の最適値

| stats\mode   | This PR (Batched) | This PR (Fallback) | Original |
| ------------ | ----------------- | ------------------ | -------- |
| Runtime      | 3.83 sec          | 7.28 sec           | 6.93 sec |
| `best_value` | `237.65`          | `244.74`           | `244.74` |

#### 結果2. Trialの初期では、どの手法も最適解がほとんど一致する

| Trial | Mode               | x0                  | x1                  | x2                 | x3                 | x4                   | x5                   | x6                  | x7                  | x8                  | x9                  |
| ----- | ------------------ | ------------------- | ------------------- | ------------------ | ------------------ | -------------------- | -------------------- | ------------------- | ------------------- | ------------------- | ------------------- |
| 9     | Original           | -3.804057540616983  | 2.13244787222995    | 2.6078504861689744 | 0.6127719756949623 | 2.70967179954561     | -0.06204403635609257 | 0.22732829381994057 | -0.7245898164145037 | -4.745808732559048  | -3.9210857300669555 |
| 9     | This PR (Batched)  | -3.804057540616983  | 2.13244787222995    | 2.6078504861689744 | 0.6127719756949623 | 2.70967179954561     | -0.06204403635609257 | 0.22732829381994057 | -0.7245898164145037 | -4.745808732559048  | -3.9210857300669555 |
| 9     | This PR (Fallback) | -3.804057540616983  | 2.13244787222995    | 2.6078504861689744 | 0.6127719756949623 | 2.70967179954561     | -0.06204403635609257 | 0.22732829381994057 | -0.7245898164145037 | -4.745808732559048  | -3.9210857300669555 |
| 10    | Original           | -1.3521177949369183 | 1.884266535593106   | 4.70204332494208   | -4.686924455161294 | -4.6354277897651714  | -2.3837020295767584  | -2.54981063903124   | 3.9415049978118173  | -1.6310927165179656 | 4.931715192849079   |
| 10    | This PR (Batched)  | -1.3521177949369196 | 1.8842665355931043  | 4.702043324942078  | -4.686924455161291 | -4.63542778976517    | -2.3837020295767584  | -2.549810639031241  | 3.9415049978118155  | -1.631092716517966  | 4.931715192849079   |
| 10    | This PR (Fallback) | -1.3521177949369183 | 1.884266535593106   | 4.70204332494208   | -4.686924455161294 | -4.6354277897651714  | -2.3837020295767584  | -2.54981063903124   | 3.9415049978118173  | -1.6310927165179656 | 4.931715192849079   |
| 11    | Original           | -5.0                | -1.892109777045477  | 4.820142793954346  | 1.0039349678224934 | -5.0                 | -3.697589945694035   | -5.0                | 2.754227122961276   | -3.5443272688740404 | 4.676866136900413   |
| 11    | This PR (Batched)  | -5.0                | -1.8921097770447028 | 4.8201427939542185 | 1.003934967822202  | -5.0                 | -3.6975899456937182  | -5.0                | 2.754227122961492   | -3.5443272688737926 | 4.676866136900205   |
| 11    | This PR (Fallback) | -5.0                | -1.892109777045477  | 4.820142793954346  | 1.0039349678224934 | -5.0                 | -3.697589945694035   | -5.0                | 2.754227122961276   | -3.5443272688740404 | 4.676866136900413   |
| 12    | Original           | -0.8626904715067383 | 4.674728777076599   | 3.194588418725715  | -5.0               | -2.5966914635931295  | 1.0571190988778252   | -3.83263148929858   | 5.0                 | -2.138699815403413  | 4.712237655426524   |
| 12    | This PR (Batched)  | -0.8626904715060384 | 4.674728777076606   | 3.1945884187257327 | -5.0               | -2.5966914635929017  | 1.0571190988777293   | -3.8326314892982216 | 5.0                 | -2.138699815403209  | 4.712237655426639   |
| 12    | This PR (Fallback) | -0.8626904715067383 | 4.674728777076599   | 3.194588418725715  | -5.0               | -2.5966914635931295  | 1.0571190988778252   | -3.83263148929858   | 5.0                 | -2.138699815403413  | 4.712237655426524   |
| 13    | Original           | 1.7035918959822158  | 1.0887440040837895  | 4.13002366414174   | -5.0               | -0.16427108729306106 | -0.7893759531056306  | 0.1100295124370465  | 5.0                 | 3.3421161858848354  | 5.0                 |
| 13    | This PR (Batched)  | 1.70359189598196    | 1.0887440040837895  | 4.130023664141895  | -5.0               | -0.16427108729281947 | -0.7893759531055453  | 0.11002951243717529 | 5.0                 | 3.342116185885919   | 5.0                 |
| 13    | This PR (Fallback) | 1.7035918959822158  | 1.0887440040837895  | 4.13002366414174   | -5.0               | -0.16427108729306106 | -0.7893759531056306  | 0.1100295124370465  | 5.0                 | 3.3421161858848354  | 5.0                 |

---

## 考察 (Discussion)

- **実行時間**:
    - バッチ評価が機能した場合、実行時間が短縮されることが確認できました。特に、連続変数のみで構成される`f6`ベンチマークでは、約45%の高速化が達成されています。
    - フォールバックした場合の実行時間は、`Original`とほぼ同等であり、本実装によるオーバーヘッドが軽微であり、実装に不備がないと示唆されます。
- **精度**:
    - 100 Trials 後の`best_value`は、いずれの方式でも同等のオーダーに達しており、提案手法が最適化の精度を大きく損なっていないことが確認できました。
    - 初期のTrial（例: 9〜13）における提案パラメータは、数値誤差の範囲でほぼ一致しており、アルゴリズムの妥当性が示されています。
